### PR TITLE
Import once

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agile-ci-scripts
 
-> a couple scripts to help with travis builds
+> a couple of shell functions to help with travis builds
 
 Requirements:
 

--- a/after_success.sh
+++ b/after_success.sh
@@ -1,14 +1,23 @@
 # If a docker tag and image is present let's push it to dockerhub
+function docker_push_if_needed {
 if [[ -n ${DOCKER_TAG} && ${DOCKER_IMAGE} ]]; then
   docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
   docker push $DOCKER_IMAGE:$DOCKER_TAG;
 else
   echo "DOCKER_TAG & DOCKER_IMAGE is not set, aborting push to dockerhub"
+  return 0
 fi
+}
 
+function versionist_if_needed {
 # If is on master and doesn't have tag and it's instructed by the versionist envar then run versionist
 if [[ ${TRAVIS_PULL_REQUEST} == "false" && ${TRAVIS_BRANCH} == "master" && -z ${TRAVIS_TAG} && VERSIONIST ]]; then
   git checkout master;
   git remote set-url origin https://$GH_TOKEN@github.com/agile-iot/$COMPONENT.git;
   versionist;
 fi
+
+}
+
+docker_push_if_needed
+versionist_if_needed

--- a/after_success.sh
+++ b/after_success.sh
@@ -1,21 +1,21 @@
 # If a docker tag and image is present let's push it to dockerhub
 function docker_push_if_needed {
-if [[ -n ${DOCKER_TAG} && ${DOCKER_IMAGE} ]]; then
-  docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-  docker push $DOCKER_IMAGE:$DOCKER_TAG;
-else
-  echo "DOCKER_TAG & DOCKER_IMAGE is not set, aborting push to dockerhub"
-  return 0
-fi
+  if [[ -n ${DOCKER_TAG} && ${DOCKER_IMAGE} ]]; then
+    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+    docker push $DOCKER_IMAGE:$DOCKER_TAG;
+  else
+    echo "DOCKER_TAG & DOCKER_IMAGE is not set, aborting push to dockerhub"
+    return 0
+  fi
 }
 
-function versionist_if_needed {
 # If is on master and doesn't have tag and it's instructed by the versionist envar then run versionist
-if [[ ${TRAVIS_PULL_REQUEST} == "false" && ${TRAVIS_BRANCH} == "master" && -z ${TRAVIS_TAG} && VERSIONIST ]]; then
-  git checkout master;
-  git remote set-url origin https://$GH_TOKEN@github.com/agile-iot/$COMPONENT.git;
-  versionist;
-fi
+function versionist_if_needed {
+  if [[ ${TRAVIS_PULL_REQUEST} == "false" && ${TRAVIS_BRANCH} == "master" && -z ${TRAVIS_TAG} && VERSIONIST ]]; then
+    git checkout master;
+    git remote set-url origin https://$GH_TOKEN@github.com/agile-iot/$COMPONENT.git;
+    versionist;
+  fi
 
 }
 

--- a/agile-ci-functions.sh
+++ b/agile-ci-functions.sh
@@ -10,6 +10,11 @@ function get_docker_tag {
     echo "$TRAVIS_TAG";
     return 0;
   fi
+  if [[ ${TRAVIS_PULL_REQUEST} == "false" && -z ${TRAVIS_TAG} ]]; then
+    echo "$TRAVIS_BRANCH";
+    return 0;
+  fi
+
 }
 
 function bootstrap {

--- a/agile-ci-functions.sh
+++ b/agile-ci-functions.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+function get_docker_tag {
+  # if is PR set DOCKER_TAG to PR BRANCH NAME
+  if [[ ${TRAVIS_PULL_REQUEST} != "false" ]]; then
+    echo "$TRAVIS_PULL_REQUEST_BRANCH-$TRAVIS_PULL_REQUEST_SHA";
+    return 0;
+  fi
+  # if is not PR but has a git tag
+  if [[ ${TRAVIS_PULL_REQUEST} == "false" && -n ${TRAVIS_TAG} ]]; then
+    echo "$TRAVIS_TAG";
+    return 0;
+  fi
+}
+
+function bootstrap {
+  export DOCKER_TAG
+  DOCKER_TAG=$(get_docker_tag)
+  echo "DOCKER_TAG set as $DOCKER_TAG"
+  git fetch --tags
+  git config --global user.name "Agile CI Bot" && git config --global user.email "bot@http://agile-iot.eu/"
+  docker run --rm --privileged multiarch/qemu-user-static:register
+  if [ "$BASEIMAGE" ] ; then sed -i "s/^FROM .*/FROM $BASEIMAGE/" Dockerfile ; fi
+  if [ -f "package.json" ]; then
+  	echo "contains package.json - expect dependencies to be installed"
+  else
+    npm i git://github.com/resin-io/versionist.git#agile versionist-plugins;
+  fi
+}
+
+# If a docker tag and image is present let's push it to dockerhub
+function docker_push_if_needed {
+  if [[ -n ${DOCKER_TAG} && ${DOCKER_IMAGE} ]]; then
+    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+    docker push $DOCKER_IMAGE:$DOCKER_TAG;
+  else
+    echo "DOCKER_TAG & DOCKER_IMAGE is not set, aborting push to dockerhub"
+    return 0
+  fi
+}
+
+# If is on master and doesn't have tag and it's instructed by the versionist envar then run versionist
+function versionist_if_needed {
+  if [[ ${TRAVIS_PULL_REQUEST} == "false" && ${TRAVIS_BRANCH} == "master" && -z ${TRAVIS_TAG} && VERSIONIST ]]; then
+    git checkout master;
+    git remote set-url origin https://$GH_TOKEN@github.com/agile-iot/$COMPONENT.git;
+    versionist;
+  fi
+}
+

--- a/agile-ci-functions.sh
+++ b/agile-ci-functions.sh
@@ -34,6 +34,13 @@ function bootstrap {
   fi
 }
 
+# build docker image
+function docker_build_if_needed {
+  if [[ -n ${DOCKER_TAG} ]]; then
+    docker build -t $DOCKER_IMAGE:$DOCKER_TAG .;
+  fi
+}
+
 # If a docker tag and image is present let's push it to dockerhub
 function docker_push_if_needed {
   if [[ -n ${DOCKER_TAG} && ${DOCKER_IMAGE} ]]; then

--- a/agile-ci-functions.sh
+++ b/agile-ci-functions.sh
@@ -25,11 +25,12 @@ function bootstrap {
   git config --global user.name "Agile CI Bot" && git config --global user.email "bot@http://agile-iot.eu/"
   docker run --rm --privileged multiarch/qemu-user-static:register
   if [ "$BASEIMAGE" ] ; then sed -i "s/^FROM .*/FROM $BASEIMAGE/" Dockerfile ; fi
-  if [ -f "package.json" ]; then
-  	echo "contains package.json - expect dependencies to be installed"
-  else
-    npm i git://github.com/resin-io/versionist.git#agile versionist-plugins;
-  fi
+  if [ "$VERSIONIST" == "true"]
+    if [ -f "package.json" ]; then
+      echo "contains package.json - expect dependencies to be installed"
+    else
+      npm i git://github.com/resin-io/versionist.git#agile versionist-plugins;
+    fi
 }
 
 # If a docker tag and image is present let's push it to dockerhub

--- a/agile-ci-functions.sh
+++ b/agile-ci-functions.sh
@@ -46,6 +46,11 @@ function docker_push_if_needed {
   if [[ -n ${DOCKER_TAG} && ${DOCKER_IMAGE} ]]; then
     docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
     docker push $DOCKER_IMAGE:$DOCKER_TAG;
+    #push master as latest
+    if [ "$DOCKER_TAG" == "master" ]; then
+      docker tag $DOCKER_IMAGE:$DOCKER_TAG $DOCKER_IMAGE;
+      docker push $DOCKER_IMAGE;
+    fi
   else
     echo "DOCKER_TAG & DOCKER_IMAGE is not set, aborting push to dockerhub"
   fi

--- a/agile-ci-functions.sh
+++ b/agile-ci-functions.sh
@@ -39,7 +39,6 @@ function docker_push_if_needed {
     docker push $DOCKER_IMAGE:$DOCKER_TAG;
   else
     echo "DOCKER_TAG & DOCKER_IMAGE is not set, aborting push to dockerhub"
-    return 0
   fi
 }
 

--- a/agile-ci-functions.sh
+++ b/agile-ci-functions.sh
@@ -44,7 +44,7 @@ function docker_push_if_needed {
 
 # If is on master and doesn't have tag and it's instructed by the versionist envar then run versionist
 function versionist_if_needed {
-  if [[ ${TRAVIS_PULL_REQUEST} == "false" && ${TRAVIS_BRANCH} == "master" && -z ${TRAVIS_TAG} && VERSIONIST ]]; then
+  if [[ ${TRAVIS_PULL_REQUEST} == "false" && ${TRAVIS_BRANCH} == "master" && -z ${TRAVIS_TAG} && "$VERSIONIST" == "true" ]]; then
     git checkout master;
     git remote set-url origin https://$GH_TOKEN@github.com/agile-iot/$COMPONENT.git;
     versionist;

--- a/agile-ci-functions.sh
+++ b/agile-ci-functions.sh
@@ -29,7 +29,7 @@ function bootstrap {
     if [ -f "package.json" ]; then
       echo "contains package.json - expect dependencies to be installed"
     else
-      npm i git://github.com/resin-io/versionist.git#agile versionist-plugins;
+      npm i versionist versionist-plugins;
     fi
   fi
 }

--- a/agile-ci-functions.sh
+++ b/agile-ci-functions.sh
@@ -34,6 +34,11 @@ function bootstrap {
   fi
 }
 
+function docker_upgrade {
+  wget https://download.docker.com/linux/ubuntu/dists/trusty/pool/test/amd64/docker-ce_17.05.0~ce~rc3-0~ubuntu-trusty_amd64.deb
+  sudo dpkg -i --force-confnew docker-ce_17.05.0~ce~rc3-0~ubuntu-trusty_amd64.deb
+}
+
 # build docker image
 function docker_build_if_needed {
   if [[ -n ${DOCKER_TAG} ]]; then

--- a/agile-ci-functions.sh
+++ b/agile-ci-functions.sh
@@ -72,7 +72,7 @@ function versionist_if_needed {
 
 # Load Travis cache file into docker images, if available
 function cache_load {
-  if [ -f $DOCKER_CACHE_FILE ]; then
+  if [ -f "$DOCKER_CACHE_FILE" ]; then
     gunzip -c $DOCKER_CACHE_FILE | docker load || true;
   fi
 }

--- a/agile-ci-functions.sh
+++ b/agile-ci-functions.sh
@@ -25,12 +25,13 @@ function bootstrap {
   git config --global user.name "Agile CI Bot" && git config --global user.email "bot@http://agile-iot.eu/"
   docker run --rm --privileged multiarch/qemu-user-static:register
   if [ "$BASEIMAGE" ] ; then sed -i "s/^FROM .*/FROM $BASEIMAGE/" Dockerfile ; fi
-  if [ "$VERSIONIST" == "true"]
+  if [ "$VERSIONIST" == "true" ]; then
     if [ -f "package.json" ]; then
       echo "contains package.json - expect dependencies to be installed"
     else
       npm i git://github.com/resin-io/versionist.git#agile versionist-plugins;
     fi
+  fi
 }
 
 # If a docker tag and image is present let's push it to dockerhub

--- a/agile-ci-functions.sh
+++ b/agile-ci-functions.sh
@@ -47,3 +47,18 @@ function versionist_if_needed {
   fi
 }
 
+# Load Travis cache file into docker images, if available
+function cache_load {
+  if [ -f $DOCKER_CACHE_FILE ]; then
+    gunzip -c $DOCKER_CACHE_FILE | docker load || true;
+  fi
+}
+
+# Save docker images to Travis cache.
+# Note: This has to be called in "script", otherwise the cache is not saved by Travis
+function cache_save {
+  if [[ ${TRAVIS_PULL_REQUEST} == "false" ]]; then
+    mkdir -p $(dirname ${DOCKER_CACHE_FILE});
+    docker save $(docker history -q $IMAGE:$DOCKER_TAG | grep -v '<missing>') | gzip > ${DOCKER_CACHE_FILE};
+  fi
+}

--- a/agile-ci-functions.sh
+++ b/agile-ci-functions.sh
@@ -65,6 +65,6 @@ function cache_load {
 function cache_save {
   if [[ ${TRAVIS_PULL_REQUEST} == "false" ]]; then
     mkdir -p $(dirname ${DOCKER_CACHE_FILE});
-    docker save $(docker history -q $IMAGE:$DOCKER_TAG | grep -v '<missing>') | gzip > ${DOCKER_CACHE_FILE};
+    docker save $(docker history -q $DOCKER_IMAGE:$DOCKER_TAG | grep -v '<missing>') | gzip > ${DOCKER_CACHE_FILE};
   fi
 }


### PR DESCRIPTION
Rewrite ci-scripts to expose a library of functions. This way, it just needs to be imported once, and then the functions can be freely used to compose the build process. Functions are not anymore named by their location in the travis file, since that might slightly change between uses, but are named based on their actual functionality.

The PR also adds 
 - docker+travis caching support
 - branch based docker tagging
 - latest tag support
 - docker engine update
This goes together with a pull request on agile-example, to be linked.

Old scripts are not removed to smooth the transition. Should be removed in a follow-up commit.