### PR TITLE
use docker ARG for baseimage replacement

### DIFF
--- a/agile-ci-functions.sh
+++ b/agile-ci-functions.sh
@@ -42,7 +42,13 @@ function docker_upgrade {
 # build docker image
 function docker_build_if_needed {
   if [[ -n ${DOCKER_TAG} ]]; then
-    docker build -t $DOCKER_IMAGE:$DOCKER_TAG .;
+    if [[ -n ${BASEIMAGE_BUILD} ]]; then
+      DOCKER_BUILD_ARGS+=" --build-arg BASEIMAGE_BUILD=$BASEIMAGE_BUILD"
+    fi
+    if [[ -n ${BASEIMAGE_DEPLOY} ]]; then
+      DOCKER_BUILD_ARGS+=" --build-arg BASEIMAGE_DEPLOY=$BASEIMAGE_DEPLOY"
+    fi
+    docker build $DOCKER_BUILD_ARGS -t $DOCKER_IMAGE:$DOCKER_TAG .;
   fi
 }
 


### PR DESCRIPTION
This uses https://github.com/Agile-IoT/agile-ci-scripts/issues/7 to simplify the build process.

Default values can still be specified in the Dockerfile, so docker commands and compose commands still work.

I've also left in the old `sed` based method (which has a pending fix in https://github.com/Agile-IoT/agile-ci-scripts/pull/6) to simplify transition.

Signed-off-by: Csaba Kiraly <csaba.kiraly@gmail.com>